### PR TITLE
ci(deploy): remove test job dependency from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    needs: test
     steps:
       - uses: actions/checkout@v4
       - name: Build & Deploy Worker


### PR DESCRIPTION
The test job is no longer required as a prerequisite for deployment, allowing the deploy workflow to run independently